### PR TITLE
Fix closing code tag in the syntax guide

### DIFF
--- a/web/src/plugins/logs/SyntaxGuide.vue
+++ b/web/src/plugins/logs/SyntaxGuide.vue
@@ -37,8 +37,8 @@
                 <li>
                   For full text search of value 'error' use
                   <span class="bg-highlight"
-                    >match_all('error') in query editor</span
-                  >
+                    >match_all('error')
+                  > in query editor</span
                 </li>
                 <li>
                   For case-insensitive full text search of value 'error' use


### PR DESCRIPTION
Before:
> For full text search of value 'error' use `match_all('error') in query editor`

After: (Hopefully. I did not test)
> For full text search of value 'error' use `match_all('error')` in query editor